### PR TITLE
Addresses now work in the form

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -26,7 +26,7 @@ class EventsController < ApplicationController
   # GET /events/new.xml
   def new
     @event = Event.new
-
+    @event.build_address if !@event.address
     respond_to do |format|
       format.html # new.html.erb
       format.xml  { render :xml => @event }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,9 +1,9 @@
 module ApplicationHelper
 
-	def setup_event(event)
-			returning(event) do |e|
-				e.address.build if e.address.empty?
-			end
-	end
+  # def setup_event(event)
+  #     returning(event) do |e|
+  #       e.address.build if e.address.empty?
+  #     end
+  # end
 
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,4 +1,5 @@
 class Event < ActiveRecord::Base
+  #attr_accessible :address_attributes
   has_one :address
 	accepts_nested_attributes_for :address, :allow_destroy => true
 end

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -23,20 +23,20 @@
   </div>
 	<div class="field">
 <%#TODO: figure out why this damned form isn't rendering %>
-	<% f.fields_for :address do |af| %>
-		<%= f.label :line1 %>
+	<%= f.fields_for :address do |af| %>
+		<%= af.label :line1 %>
 		<%= af.text_field :line1 %><br/>
-		<%= f.label :line2 %>
+		<%= af.label :line2 %>
 		<%= af.text_field :line2 %><br/>
-		<%= f.label :line3 %>
+		<%= af.label :line3 %>
 		<%= af.text_field :line3 %><br/>
-		<%= f.label :neighborhood %> <%= af.text_field :neighborhood %><br/>
-		<%= f.label :city %> <%= af.text_field :city %><br/>
-		<%= f.label :region %> <%= af.text_field :region %><br/>
-		<%= f.label :country %> <%= af.text_field :country %><br/>
-		<%= f.label :postcode %> <%= af.text_field :postcode %><br/>
-		<%= f.label :phone %> <%= af.telephone_field :phone %><br/>
-		<%= f.label :type %> <%= af.select :type, Address::TYPES %>
+		<%= af.label :neighborhood %> <%= af.text_field :neighborhood %><br/>
+		<%= af.label :city %> <%= af.text_field :city %><br/>
+		<%= af.label :region %> <%= af.text_field :region %><br/>
+		<%= af.label :country %> <%= af.text_field :country %><br/>
+		<%= af.label :postcode %> <%= af.text_field :postcode %><br/>
+		<%= af.label :phone %> <%= af.telephone_field :phone %><br/>
+		<%= af.label :type %> <%= af.select :type, Address::TYPES %>
 		<%= af.hidden_field :primary, :value => true %>
 	<% end %>
 	</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,8 @@
 Plas::Application.routes.draw do
-  resources :events
+
+  resources :events do
+    resource :address
+  end
 
 # http://www.engineyard.com/blog/2010/the-lowdown-on-routes-in-rails-3/
 	resource :account, :controller => "users"

--- a/db/migrate/20100916162718_adjust_event_address_relation.rb
+++ b/db/migrate/20100916162718_adjust_event_address_relation.rb
@@ -1,0 +1,13 @@
+class AdjustEventAddressRelation < ActiveRecord::Migration
+  def self.up
+    add_column :addresses, :event_id, :integer
+    add_index :addresses, :event_id
+    remove_column :events, :address_id
+  end
+
+  def self.down
+    remove_column :addresses, :event_id, :integer
+    remove_index :addresses, :event_id
+    add_column :events, :address_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20100915035041) do
+ActiveRecord::Schema.define(:version => 20100916162718) do
 
   create_table "addresses", :force => true do |t|
     t.string   "line1"
@@ -27,13 +27,15 @@ ActiveRecord::Schema.define(:version => 20100915035041) do
     t.integer  "user_id"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.integer  "event_id"
   end
+
+  add_index "addresses", ["event_id"], :name => "index_addresses_on_event_id"
 
   create_table "events", :force => true do |t|
     t.string   "name"
     t.datetime "start"
     t.datetime "end"
-    t.integer  "address_id"
     t.boolean  "registration_open"
     t.boolean  "visible"
     t.text     "description"


### PR DESCRIPTION
I had to add a new migration to switch some fields around (a event_id in the addresses table, and you don't need address_id in the events table), and the form now displays and saves the actual address. And will display on edit to change as well.
